### PR TITLE
PetIBM v0.5.2 scripts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
-Copyright (c) 2019-2020, Olivier Mesnard
+Copyright (c) 2019, Olivier Mesnard
+Copyright (c) 2020, Olivier Mesnard, Pi-Yueh Chuang
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Dockerfiles are located in the `docker` folder; Singularity recipes are in the `
 
 Docker and Singularity images are available for:
 
-* PetIBM (0.4.2, 0.5, 0.5.1)
+* PetIBM (0.4.2, 0.5, 0.5.1, 0.5.2)
 
 ## Contact
 

--- a/docker/Dockerfile-0.5.2-GPU-OpenMPI-centos7
+++ b/docker/Dockerfile-0.5.2-GPU-OpenMPI-centos7
@@ -6,72 +6,82 @@
 #   - PETSc 3.12.5
 #   - AmgXWrapper 1a93865
 #   - PetIBM v0.5.2
-#
-# TODO: move all yum commands to the begining layer
-# TODO: use global ARG to avoid duplicated environment variables in both stages
 
+
+# use ARGs as a hack for global variables
+ARG OMPI_SERIES="4.0"
+ARG OMPI_VERSION="4.0.5"
+ARG AMGX_VERSION="919fb92a2c02ea3d8d3d0f0660e3b507d84705bc"
+ARG PETSC_VERSION="3.12.5"
+ARG AMGXWRAPPER_VERSION="1a93865fe885b3a3530e4022aacc00845beb1177"
+ARG PETIBM_VERSION="0.5.2"
 
 # Multi-stage build stage 0: build
 # =================================
-FROM nvidia/cuda:10.1-devel-centos7
+FROM nvidia/cuda:10.1-devel-centos7 as builder
 
-# version variables
-ENV OMPI_SERIES="4.0" \
-    OMPI_VERSION="4.0.5" \
-    AMGX_VERSION="919fb92a2c02ea3d8d3d0f0660e3b507d84705bc" \
-    PETSC_VERSION="3.12.5" \
-    AMGXWRAPPER_VERSION="1a93865fe885b3a3530e4022aacc00845beb1177" \
-    PETIBM_VERSION="0.5.2"
+# re-include the global variables
+ARG OMPI_SERIES
+ARG OMPI_VERSION
+ARG AMGX_VERSION
+ARG PETSC_VERSION
+ARG AMGXWRAPPER_VERSION
+ARG PETIBM_VERSION
 
+# installation paths
 ENV OMPI_DIR="/usr/local/openmpi-${OMPI_VERSION}" \
     AMGX_DIR="/usr/local/amgx-${AMGX_VERSION}" \
     PETSC_DIR="/usr/local/petsc-${PETSC_VERSION}" \
+    PETSC_ARCH="" \
     AMGXWRAPPER_DIR="/usr/local/amgxwrapper-${AMGXWRAPPER_VERSION}" \
     PETIBM_DIR="/usr/local/petibm-${PETIBM_VERSION}"
 
-# add OpenMPI paths
-ENV PATH="${OMPI_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${OMPI_DIR}/lib:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${OMPI_DIR}/lib:${LD_LIBRARY_PATH}" \
-    CPATH="${OMPI_DIR}/include:${CPATH}"
-
-# add AmgX paths
-ENV PATH="${AMGX_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${AMGX_DIR}/lib:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${AMGX_DIR}/lib:${LD_LIBRARY_PATH}" \
-    LIBRARY_PATH="${AMGX_DIR}/lib:${LIBRARY_PATH}" \
-    CPATH="${AMGX_DIR}/include:${CPATH}"
-
-# add PETSc paths
-ENV PETSC_ARCH="" \
-    PATH="${PETSC_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${PETSC_DIR}/lib:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${PETSC_DIR}/lib:${LD_LIBRARY_PATH}" \
-    LIBRARY_PATH="${PETSC_DIR}/lib:${LIBRARY_PATH}" \
-    CPATH="${PETSC_DIR}/include:${CPATH}"
-
-# add AmgXWrapper paths
-ENV PATH="${AMGXWRAPPER_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${AMGXWRAPPER_DIR}/lib64:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${AMGXWRAPPER_DIR}/lib64:${LD_LIBRARY_PATH}" \
-    LIBRARY_PATH="${AMGXWRAPPER_DIR}/lib64:${LIBRARY_PATH}" \
-    CPATH="${AMGXWRAPPER_DIR}/include:${CPATH}"
-
-# add PetIBM paths
-ENV PATH="${PETIBM_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${PETIBM_DIR}/lib:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${PETIBM_DIR}/lib:${LD_LIBRARY_PATH}" \
-    LIBRARY_PATH="${PETIBM_DIR}/lib:${LIBRARY_PATH}" \
-    CPATH="${PETIBM_DIR}/include:${CPATH}"
+# add paths and headers' path
+ENV PATH="${OMPI_DIR}/bin:${PATH}" CPATH="${OMPI_DIR}/include:${CPATH}"
+ENV PATH="${AMGX_DIR}/bin:${PATH}" CPATH="${AMGX_DIR}/include:${CPATH}"
+ENV PATH="${PETSC_DIR}/bin:${PATH}" CPATH="${PETSC_DIR}/include:${CPATH}"
+ENV PATH="${AMGXWRAPPER_DIR}/bin:${PATH}" CPATH="${AMGXWRAPPER_DIR}/include:${CPATH}"
+ENV PATH="${PETIBM_DIR}/bin:${PATH}" CPATH="${PETIBM_DIR}/include:${CPATH}"
 
 # install required packages
 RUN yum -y group install --setopt=tsflags=nodocs "Development Tools" \
+ && yum -y install --setopt=tsflags=nodocs wget openssl-devel \
  && yum -y install centos-release-scl \
  && yum -y install --setopt=tsflags=nodocs devtoolset-8 rh-python36 \
- && yum -y install --setopt=tsflags=nodocs cmake zlib zlib-devel \
+ && yum -y install --setopt=tsflags=nodocs zlib zlib-devel \
  && yum -y group install --setopt=tsflags=nodocs "Infiniband Support" \
- && yum -y install --setopt=tsflags=nodocs ucx libverbs libfabric \
- && yum -y install --setopt=tsflags=nodocs rdma-core-devel ucx-devel libfabric-devel
+ && yum -y install --setopt=tsflags=nodocs libverbs libfabric \
+ && yum -y install --setopt=tsflags=nodocs rdma-core-devel numactl-devel libfabric-devel
+
+# newer version of cmake
+RUN source scl_source enable devtoolset-8 rh-python36 \
+ && curl -LO https://cmake.org/files/v3.18/cmake-3.18.2.tar.gz \
+ && tar xf cmake-3.18.2.tar.gz && cd cmake-3.18.2 \
+ && ./bootstrap --prefix=/usr  --parallel=6 \
+ && make -j 6 && make install \
+ && cd .. && rm -rf cmake-3.18.2 cmake-3.18.2.tar.gz
+
+# newer version of ucx
+RUN source scl_source enable devtoolset-8 rh-python36 \
+ && curl -LO https://github.com/openucx/ucx/releases/download/v1.8.1/ucx-1.8.1.tar.gz \
+ && tar xf ucx-1.8.1.tar.gz && cd ucx-1.8.1 && mkdir build && cd build \
+ && ../contrib/configure-release \
+    --prefix=/usr/local/ucx-1.8.1 \
+    --disable-doxygen-doc \
+    --with-cuda=/usr/local/cuda-10.1 \
+    --with-verbs \
+    --with-rc \
+    --with-ud \
+    --with-dc \
+    --with-mlx5-dv \
+    --with-ib-hw-tm \
+    --with-dm \
+    --with-rdmacm \
+ && make all -j && make install \
+ && cd ../.. && rm -rf ucx-1.8.1 ucx-1.8.1.tar.gz \
+ && echo "/usr/local/ucx-1.8.1/lib" > /etc/ld.so.conf.d/uxc-1.8.1.conf \
+ && echo "/usr/local/ucx-1.8.1/lib/ucx" >> /etc/ld.so.conf.d/uxc-1.8.1.conf \
+ && ldconfig
 
 # build OpenMPI
 RUN source scl_source enable devtoolset-8 rh-python36 \
@@ -82,7 +92,7 @@ RUN source scl_source enable devtoolset-8 rh-python36 \
  && ../configure \
     --prefix=${OMPI_DIR} \
     --with-hwloc \
-    --with-ucx \
+    --with-ucx=/usr/local/ucx-1.8.1 \
     --with-ofi \
     --with-slurm \
     --with-pmix \
@@ -103,7 +113,8 @@ RUN source scl_source enable devtoolset-8 rh-python36 \
     FCFLAGS="-O3" \
     CFLAGS="-O3" \
  && make all -j && make install \
- && cd ../.. && rm -rf openmpi-${OMPI_VERSION} ${TARBALL}
+ && cd ../.. && rm -rf openmpi-${OMPI_VERSION} ${TARBALL} \
+ && echo "${OMPI_DIR}/lib" > /etc/ld.so.conf.d/openmpi-${OMPI_VERSION}.conf && ldconfig
 
 # build amgx
 RUN source scl_source enable devtoolset-8 rh-python36 \
@@ -119,7 +130,8 @@ RUN source scl_source enable devtoolset-8 rh-python36 \
     -DAMGX_NO_RPATH=OFF  \
     .. \
  && make -j 6 all && make install \
- && cd ../.. && rm -rf amgx amgx.tar.gz
+ && cd ../.. && rm -rf amgx amgx.tar.gz \
+ && echo "${AMGX_DIR}/lib" > /etc/ld.so.conf.d/amgx-${AMGX_VERSION}.conf && ldconfig
 
 # build PETSc
 RUN source scl_source enable devtoolset-8 rh-python36 \
@@ -149,17 +161,8 @@ RUN source scl_source enable devtoolset-8 rh-python36 \
     --download-hdf5=1 \
  && make PETSC_DIR=${PWD} PETSC_ARCH=arch-linux-c-opt all \
  && make PETSC_DIR=${PWD} PETSC_ARCH=arch-linux-c-opt install \
- && cd .. && rm -rf petsc petsc.tar.gz
-
-# newer version of cmake (TODO: move this block to beginning)
-RUN source scl_source enable devtoolset-8 rh-python36 \
- && yum -y remove cmake \
- && yum -y install --setopt=tsflags=nodocs openssl-devel \
- && curl -LO https://cmake.org/files/v3.18/cmake-3.18.2.tar.gz \
- && tar xf cmake-3.18.2.tar.gz && cd cmake-3.18.2 \
- && ./bootstrap --prefix=/usr  --parallel=6 \
- && make -j 6 && make install \
- && cd .. && rm -rf cmake-3.18.2 cmake-3.18.2.tar.gz
+ && cd .. && rm -rf petsc petsc.tar.gz \
+ && echo "${PETSC_DIR}/lib" > /etc/ld.so.conf.d/petsc-${PETSC_VERSION}.conf && ldconfig
 
 # build AmgXWrapper
 RUN source scl_source enable devtoolset-8 rh-python36 \
@@ -176,11 +179,11 @@ RUN source scl_source enable devtoolset-8 rh-python36 \
  && cd .. && mkdir build_solveFromFiles && cd build_solveFromFiles \
  && cmake -DCUDA_DIR=/usr/local/cuda-10.1 ../example/solveFromFiles && make all -j \
  && cp bin/solveFromFiles ${AMGXWRAPPER_DIR}/bin \
- && cd ../.. && rm -rf amgxwrapper amgxwrapper.tar.gz
+ && cd ../.. && rm -rf amgxwrapper amgxwrapper.tar.gz \
+ && echo "${AMGXWRAPPER_DIR}/lib64" > /etc/ld.so.conf.d/amgxwrapper-${AMGXWRAPPER_VERSION}.conf && ldconfig
 
-# build PetIBM (# TODO: move the yum line to the beginning layer!)
+# build PetIBM
 RUN source scl_source enable devtoolset-8 rh-python36 \
- && yum -y install wget \
  && curl -L https://github.com/barbagroup/PetIBM/tarball/v${PETIBM_VERSION} -o petibm.tar.gz \
  && mkdir petibm && tar xf petibm.tar.gz -C petibm --strip-component=1 \
  && cd petibm && mkdir build && cd build \
@@ -196,62 +199,36 @@ RUN source scl_source enable devtoolset-8 rh-python36 \
     --enable-yamlcpp \
     --enable-gtest \
  && make all -j && make check && make install \
- && cd ../.. && rm -rf petibm petibm.tar.gz
+ && cd ../.. && rm -rf petibm petibm.tar.gz \
+ && echo "${PETIBM_DIR}/lib" > /etc/ld.so.conf.d/petibm-${PETIBM_VERSION}.conf && ldconfig
 
 
 # Multi-stage build stage 1: runtime image
 # =========================================
-FROM nvidia/cuda:10.1-runtime-centos7
+FROM nvidia/cuda:10.1-runtime-centos7 as production
 LABEL maintainer="Pi-Yueh Chuang <pychuang@gwu.edu>"
 
-# version variables
-ENV OMPI_SERIES="4.0" \
-    OMPI_VERSION="4.0.5" \
-    AMGX_VERSION="919fb92a2c02ea3d8d3d0f0660e3b507d84705bc" \
-    PETSC_VERSION="3.12.5" \
-    AMGXWRAPPER_VERSION="1a93865fe885b3a3530e4022aacc00845beb1177" \
-    PETIBM_VERSION="0.5.2"
+# re-include the global variables
+ARG OMPI_SERIES
+ARG OMPI_VERSION
+ARG AMGX_VERSION
+ARG PETSC_VERSION
+ARG AMGXWRAPPER_VERSION
+ARG PETIBM_VERSION
 
 ENV OMPI_DIR="/usr/local/openmpi-${OMPI_VERSION}" \
     AMGX_DIR="/usr/local/amgx-${AMGX_VERSION}" \
     PETSC_DIR="/usr/local/petsc-${PETSC_VERSION}" \
+    PETSC_ARCH="" \
     AMGXWRAPPER_DIR="/usr/local/amgxwrapper-${AMGXWRAPPER_VERSION}" \
     PETIBM_DIR="/usr/local/petibm-${PETIBM_VERSION}"
 
-# add OpenMPI paths
-ENV PATH="${OMPI_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${OMPI_DIR}/lib:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${OMPI_DIR}/lib:${LD_LIBRARY_PATH}" \
-    CPATH="${OMPI_DIR}/include:${CPATH}"
-
-# add AmgX paths
-ENV PATH="${AMGX_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${AMGX_DIR}/lib:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${AMGX_DIR}/lib:${LD_LIBRARY_PATH}" \
-    LIBRARY_PATH="${AMGX_DIR}/lib:${LIBRARY_PATH}" \
-    CPATH="${AMGX_DIR}/include:${CPATH}"
-
-# add PETSc paths
-ENV PETSC_ARCH="" \
-    PATH="${PETSC_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${PETSC_DIR}/lib:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${PETSC_DIR}/lib:${LD_LIBRARY_PATH}" \
-    LIBRARY_PATH="${PETSC_DIR}/lib:${LIBRARY_PATH}" \
-    CPATH="${PETSC_DIR}/include:${CPATH}"
-
-# add AmgXWrapper paths
-ENV PATH="${AMGXWRAPPER_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${AMGXWRAPPER_DIR}/lib64:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${AMGXWRAPPER_DIR}/lib64:${LD_LIBRARY_PATH}" \
-    LIBRARY_PATH="${AMGXWRAPPER_DIR}/lib64:${LIBRARY_PATH}" \
-    CPATH="${AMGXWRAPPER_DIR}/include:${CPATH}"
-
-# add PetIBM paths
-ENV PATH="${PETIBM_DIR}/bin:${PATH}" \
-    LD_RUN_PATH="${PETIBM_DIR}/lib:${LD_RUN_PATH}" \
-    LD_LIBRARY_PATH="${PETIBM_DIR}/lib:${LD_LIBRARY_PATH}" \
-    LIBRARY_PATH="${PETIBM_DIR}/lib:${LIBRARY_PATH}" \
-    CPATH="${PETIBM_DIR}/include:${CPATH}"
+# add paths
+ENV PATH="${OMPI_DIR}/bin:${PATH}"
+ENV PATH="${AMGX_DIR}/bin:${PATH}"
+ENV PATH="${PETSC_DIR}/bin:${PATH}"
+ENV PATH="${AMGXWRAPPER_DIR}/bin:${PATH}"
+ENV PATH="${PETIBM_DIR}/bin:${PATH}"
 
 # install required packages and settings
 RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8 \
@@ -259,16 +236,27 @@ RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8 \
  && echo UTC > /etc/timezone \
  && yum -y install --setopt=tsflags=nodocs zlib libquadmath \
  && yum -y group install --setopt=tsflags=nodocs "Infiniband Support" \
- && yum -y install --setopt=tsflags=nodocs ucx libverbs libfabric \
+ && yum -y install --setopt=tsflags=nodocs libverbs libfabric \
  && yum -y install --setopt=tsflags=nodocs openssh-clients openssh-server \
  && yum -y clean all
 
 # copy installed programs
-COPY --from=0 ${OMPI_DIR} ${OMPI_DIR}
-COPY --from=0 ${AMGX_DIR} ${AMGX_DIR}
-COPY --from=0 ${PETSC_DIR} ${PETSC_DIR}
-COPY --from=0 ${AMGXWRAPPER_DIR} ${AMGXWRAPPER_DIR}
-COPY --from=0 ${PETIBM_DIR} ${PETIBM_DIR}
+COPY --from=builder /usr/local/ucx-1.8.1 /usr/local/ucx-1.8.1
+COPY --from=builder ${OMPI_DIR} ${OMPI_DIR}
+COPY --from=builder ${AMGX_DIR} ${AMGX_DIR}
+COPY --from=builder ${PETSC_DIR} ${PETSC_DIR}
+COPY --from=builder ${AMGXWRAPPER_DIR} ${AMGXWRAPPER_DIR}
+COPY --from=builder ${PETIBM_DIR} ${PETIBM_DIR}
+
+# ldconfig
+RUN echo "/usr/local/ucx-1.8.1/lib" > /etc/ld.so.conf.d/uxc-1.8.1.conf \
+ && echo "/usr/local/ucx-1.8.1/lib/ucx" >> /etc/ld.so.conf.d/uxc-1.8.1.conf \
+ && echo "${OMPI_DIR}/lib" > /etc/ld.so.conf.d/openmpi-${OMPI_VERSION}.conf \
+ && echo "${AMGX_DIR}/lib" > /etc/ld.so.conf.d/amgx-${AMGX_VERSION}.conf \
+ && echo "${PETSC_DIR}/lib" > /etc/ld.so.conf.d/petsc-${PETSC_VERSION}.conf \
+ && echo "${AMGXWRAPPER_DIR}/lib64" > /etc/ld.so.conf.d/amgxwrapper-${AMGXWRAPPER_VERSION}.conf \
+ && echo "${PETIBM_DIR}/lib64" > /etc/ld.so.conf.d/petibm-${PETIBM_VERSION}.conf \
+ && ldconfig
 
 # set up ssh for root for MPI applications
 RUN mkdir /var/run/sshd \

--- a/docker/Dockerfile-0.5.2-GPU-OpenMPI-centos7
+++ b/docker/Dockerfile-0.5.2-GPU-OpenMPI-centos7
@@ -1,0 +1,289 @@
+# vim:ft=dockerfile
+# Packages:
+#   - CUDA 10.1
+#   - OpenMPI v4.0.5 (with Infiniband, UCX, Slurm, PMI, CUDA enabled)
+#   - AmgX 919fb92
+#   - PETSc 3.12.5
+#   - AmgXWrapper 1a93865
+#   - PetIBM v0.5.2
+#
+# TODO: move all yum commands to the begining layer
+# TODO: use global ARG to avoid duplicated environment variables in both stages
+
+
+# Multi-stage build stage 0: build
+# =================================
+FROM nvidia/cuda:10.1-devel-centos7
+
+# version variables
+ENV OMPI_SERIES="4.0" \
+    OMPI_VERSION="4.0.5" \
+    AMGX_VERSION="919fb92a2c02ea3d8d3d0f0660e3b507d84705bc" \
+    PETSC_VERSION="3.12.5" \
+    AMGXWRAPPER_VERSION="1a93865fe885b3a3530e4022aacc00845beb1177" \
+    PETIBM_VERSION="0.5.2"
+
+ENV OMPI_DIR="/usr/local/openmpi-${OMPI_VERSION}" \
+    AMGX_DIR="/usr/local/amgx-${AMGX_VERSION}" \
+    PETSC_DIR="/usr/local/petsc-${PETSC_VERSION}" \
+    AMGXWRAPPER_DIR="/usr/local/amgxwrapper-${AMGXWRAPPER_VERSION}" \
+    PETIBM_DIR="/usr/local/petibm-${PETIBM_VERSION}"
+
+# add OpenMPI paths
+ENV PATH="${OMPI_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${OMPI_DIR}/lib:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${OMPI_DIR}/lib:${LD_LIBRARY_PATH}" \
+    CPATH="${OMPI_DIR}/include:${CPATH}"
+
+# add AmgX paths
+ENV PATH="${AMGX_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${AMGX_DIR}/lib:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${AMGX_DIR}/lib:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="${AMGX_DIR}/lib:${LIBRARY_PATH}" \
+    CPATH="${AMGX_DIR}/include:${CPATH}"
+
+# add PETSc paths
+ENV PETSC_ARCH="" \
+    PATH="${PETSC_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${PETSC_DIR}/lib:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${PETSC_DIR}/lib:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="${PETSC_DIR}/lib:${LIBRARY_PATH}" \
+    CPATH="${PETSC_DIR}/include:${CPATH}"
+
+# add AmgXWrapper paths
+ENV PATH="${AMGXWRAPPER_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${AMGXWRAPPER_DIR}/lib64:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${AMGXWRAPPER_DIR}/lib64:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="${AMGXWRAPPER_DIR}/lib64:${LIBRARY_PATH}" \
+    CPATH="${AMGXWRAPPER_DIR}/include:${CPATH}"
+
+# add PetIBM paths
+ENV PATH="${PETIBM_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${PETIBM_DIR}/lib:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${PETIBM_DIR}/lib:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="${PETIBM_DIR}/lib:${LIBRARY_PATH}" \
+    CPATH="${PETIBM_DIR}/include:${CPATH}"
+
+# install required packages
+RUN yum -y group install --setopt=tsflags=nodocs "Development Tools" \
+ && yum -y install centos-release-scl \
+ && yum -y install --setopt=tsflags=nodocs devtoolset-8 rh-python36 \
+ && yum -y install --setopt=tsflags=nodocs cmake zlib zlib-devel \
+ && yum -y group install --setopt=tsflags=nodocs "Infiniband Support" \
+ && yum -y install --setopt=tsflags=nodocs ucx libverbs libfabric \
+ && yum -y install --setopt=tsflags=nodocs rdma-core-devel ucx-devel libfabric-devel
+
+# build OpenMPI
+RUN source scl_source enable devtoolset-8 rh-python36 \
+ && TARBALL=openmpi-${OMPI_VERSION}.tar.gz \
+ && curl -LO https://download.open-mpi.org/release/open-mpi/v${OMPI_SERIES}/${TARBALL} \
+ && tar xf ${TARBALL} \
+ && cd openmpi-${OMPI_VERSION} && mkdir build && cd build \
+ && ../configure \
+    --prefix=${OMPI_DIR} \
+    --with-hwloc \
+    --with-ucx \
+    --with-ofi \
+    --with-slurm \
+    --with-pmix \
+    --with-zlib \
+    --with-cuda \
+    --with-verbs \
+    --with-verbs-libdir=/usr/lib64 \
+    --with-mpi-param-check=runtime \
+    --enable-oshmem=yes \
+    --enable-debug=no \
+    --enable-mem-debug=no \
+    --enable-mem-profile=no \
+    --enable-memchecker=no \
+    --enable-picky=no \
+    --enable-heterogeneous=no \
+    CXXFLAGS="-O3" \
+    CCASFLAGS="-O3" \
+    FCFLAGS="-O3" \
+    CFLAGS="-O3" \
+ && make all -j && make install \
+ && cd ../.. && rm -rf openmpi-${OMPI_VERSION} ${TARBALL}
+
+# build amgx
+RUN source scl_source enable devtoolset-8 rh-python36 \
+ && curl -L https://github.com/NVIDIA/AMGX/tarball/${AMGX_VERSION} -o amgx.tar.gz \
+ && mkdir amgx && tar -xf amgx.tar.gz -C amgx --strip-component=1 \
+ && export CC=mpicc CXX=mpicxx && mkdir amgx/build && cd amgx/build \
+ && cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${AMGX_DIR} \
+    -DCMAKE_VERBOSE_MAKEFILE=OFF  \
+    -DCUDA_ARCH="35 52 60 70" \
+    -DCMAKE_NO_MPI=OFF \
+    -DAMGX_NO_RPATH=OFF  \
+    .. \
+ && make -j 6 all && make install \
+ && cd ../.. && rm -rf amgx amgx.tar.gz
+
+# build PETSc
+RUN source scl_source enable devtoolset-8 rh-python36 \
+ && unset PETSC_ARCH && unset PETSC_DIR \
+ && curl -L http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-${PETSC_VERSION}.tar.gz -o petsc.tar.gz \
+ && mkdir petsc && tar -xf petsc.tar.gz -C petsc --strip-component=1 && cd petsc \
+ && ./configure \
+    --prefix="/usr/local/petsc-${PETSC_VERSION}" \
+    --with-default-arch=0 \
+    --with-fortran-bindings=0 \
+    --with-precision=double \
+    --with-clanguage=C \
+    --with-shared-libraries=1 \
+    --with-cc=mpicc \
+    --with-cxx=mpicxx \
+    --with-fc=0 \
+    --with-pic=1 \
+    --with-cxx-dialect=C++11 \
+    --with-debugging=0 \
+    --COPTFLAGS="-O3" \
+    --CXXOPTFLAGS="-O3" \
+    --with-gcov=0 \
+    --with-mpi=1 \
+    --download-f2cblaslapack=1 \
+    --download-hypre=1 \
+    --download-superlu_dist=1 \
+    --download-hdf5=1 \
+ && make PETSC_DIR=${PWD} PETSC_ARCH=arch-linux-c-opt all \
+ && make PETSC_DIR=${PWD} PETSC_ARCH=arch-linux-c-opt install \
+ && cd .. && rm -rf petsc petsc.tar.gz
+
+# newer version of cmake (TODO: move this block to beginning)
+RUN source scl_source enable devtoolset-8 rh-python36 \
+ && yum -y remove cmake \
+ && yum -y install --setopt=tsflags=nodocs openssl-devel \
+ && curl -LO https://cmake.org/files/v3.18/cmake-3.18.2.tar.gz \
+ && tar xf cmake-3.18.2.tar.gz && cd cmake-3.18.2 \
+ && ./bootstrap --prefix=/usr  --parallel=6 \
+ && make -j 6 && make install \
+ && cd .. && rm -rf cmake-3.18.2 cmake-3.18.2.tar.gz
+
+# build AmgXWrapper
+RUN source scl_source enable devtoolset-8 rh-python36 \
+ && curl -L https://github.com/barbagroup/AmgXWrapper/tarball/${AMGXWRAPPER_VERSION} -o amgxwrapper.tar.gz \
+ && mkdir amgxwrapper && tar -xf amgxwrapper.tar.gz -C amgxwrapper --strip-component=1 \
+ && cd amgxwrapper && mkdir build && cd build \
+ && export CC=mpicc && export CXX=mpicxx \
+ && cmake -DCUDA_DIR=/usr/local/cuda-10.1 -DCMAKE_INSTALL_PREFIX=${AMGXWRAPPER_DIR} .. \
+ && make all -j && make install \
+ && cd .. && mkdir build_poisson && cd build_poisson \
+ && cmake -DCUDA_DIR=/usr/local/cuda-10.1 ../example/poisson && make all -j \
+ && mkdir ${AMGXWRAPPER_DIR}/bin && cp bin/poisson ${AMGXWRAPPER_DIR}/bin \
+ && cp -r configs ${AMGXWRAPPER_DIR} \
+ && cd .. && mkdir build_solveFromFiles && cd build_solveFromFiles \
+ && cmake -DCUDA_DIR=/usr/local/cuda-10.1 ../example/solveFromFiles && make all -j \
+ && cp bin/solveFromFiles ${AMGXWRAPPER_DIR}/bin \
+ && cd ../.. && rm -rf amgxwrapper amgxwrapper.tar.gz
+
+# build PetIBM (# TODO: move the yum line to the beginning layer!)
+RUN source scl_source enable devtoolset-8 rh-python36 \
+ && yum -y install wget \
+ && curl -L https://github.com/barbagroup/PetIBM/tarball/v${PETIBM_VERSION} -o petibm.tar.gz \
+ && mkdir petibm && tar xf petibm.tar.gz -C petibm --strip-component=1 \
+ && cd petibm && mkdir build && cd build \
+ && ../configure \
+    CXX=mpicxx \
+    CXXFLAGS="-O2 -std=c++14" \
+    --prefix=${PETIBM_DIR} \
+    --with-petsc-dir=${PETSC_DIR} \
+    --with-petsc-arch=${PETSC_ARCH} \
+    --with-cuda-dir=/usr/local/cuda-10.1 \
+    --with-amgx-dir=${AMGX_DIR} \
+    --with-amgxwrapper-dir=${AMGXWRAPPER_DIR} \
+    --enable-yamlcpp \
+    --enable-gtest \
+ && make all -j && make check && make install \
+ && cd ../.. && rm -rf petibm petibm.tar.gz
+
+
+# Multi-stage build stage 1: runtime image
+# =========================================
+FROM nvidia/cuda:10.1-runtime-centos7
+LABEL maintainer="Pi-Yueh Chuang <pychuang@gwu.edu>"
+
+# version variables
+ENV OMPI_SERIES="4.0" \
+    OMPI_VERSION="4.0.5" \
+    AMGX_VERSION="919fb92a2c02ea3d8d3d0f0660e3b507d84705bc" \
+    PETSC_VERSION="3.12.5" \
+    AMGXWRAPPER_VERSION="1a93865fe885b3a3530e4022aacc00845beb1177" \
+    PETIBM_VERSION="0.5.2"
+
+ENV OMPI_DIR="/usr/local/openmpi-${OMPI_VERSION}" \
+    AMGX_DIR="/usr/local/amgx-${AMGX_VERSION}" \
+    PETSC_DIR="/usr/local/petsc-${PETSC_VERSION}" \
+    AMGXWRAPPER_DIR="/usr/local/amgxwrapper-${AMGXWRAPPER_VERSION}" \
+    PETIBM_DIR="/usr/local/petibm-${PETIBM_VERSION}"
+
+# add OpenMPI paths
+ENV PATH="${OMPI_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${OMPI_DIR}/lib:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${OMPI_DIR}/lib:${LD_LIBRARY_PATH}" \
+    CPATH="${OMPI_DIR}/include:${CPATH}"
+
+# add AmgX paths
+ENV PATH="${AMGX_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${AMGX_DIR}/lib:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${AMGX_DIR}/lib:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="${AMGX_DIR}/lib:${LIBRARY_PATH}" \
+    CPATH="${AMGX_DIR}/include:${CPATH}"
+
+# add PETSc paths
+ENV PETSC_ARCH="" \
+    PATH="${PETSC_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${PETSC_DIR}/lib:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${PETSC_DIR}/lib:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="${PETSC_DIR}/lib:${LIBRARY_PATH}" \
+    CPATH="${PETSC_DIR}/include:${CPATH}"
+
+# add AmgXWrapper paths
+ENV PATH="${AMGXWRAPPER_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${AMGXWRAPPER_DIR}/lib64:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${AMGXWRAPPER_DIR}/lib64:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="${AMGXWRAPPER_DIR}/lib64:${LIBRARY_PATH}" \
+    CPATH="${AMGXWRAPPER_DIR}/include:${CPATH}"
+
+# add PetIBM paths
+ENV PATH="${PETIBM_DIR}/bin:${PATH}" \
+    LD_RUN_PATH="${PETIBM_DIR}/lib:${LD_RUN_PATH}" \
+    LD_LIBRARY_PATH="${PETIBM_DIR}/lib:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="${PETIBM_DIR}/lib:${LIBRARY_PATH}" \
+    CPATH="${PETIBM_DIR}/include:${CPATH}"
+
+# install required packages and settings
+RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8 \
+ && ln -snf /usr/share/zoneinfo/UTC /etc/localtime \
+ && echo UTC > /etc/timezone \
+ && yum -y install --setopt=tsflags=nodocs zlib libquadmath \
+ && yum -y group install --setopt=tsflags=nodocs "Infiniband Support" \
+ && yum -y install --setopt=tsflags=nodocs ucx libverbs libfabric \
+ && yum -y install --setopt=tsflags=nodocs openssh-clients openssh-server \
+ && yum -y clean all
+
+# copy installed programs
+COPY --from=0 ${OMPI_DIR} ${OMPI_DIR}
+COPY --from=0 ${AMGX_DIR} ${AMGX_DIR}
+COPY --from=0 ${PETSC_DIR} ${PETSC_DIR}
+COPY --from=0 ${AMGXWRAPPER_DIR} ${AMGXWRAPPER_DIR}
+COPY --from=0 ${PETIBM_DIR} ${PETIBM_DIR}
+
+# set up ssh for root for MPI applications
+RUN mkdir /var/run/sshd \
+ && ssh-keygen -A \
+ && sed -i "s/#PermitRootLogin\ yes/PermitRootLogin\ yes/" /etc/ssh/sshd_config \
+ && sed -i "s/session\s*required\s*pam_loginuid.so/session\ optional\ pam_loginuid.so/g" /etc/pam.d/sshd \
+ && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
+ && echo "Host 10.*" > /root/.ssh/config \
+ && echo "  Port 23" >> /root/.ssh/config \
+ && echo "  StrictHostKeyChecking no" >> /root/.ssh/config \
+ && echo "  UserKnownHostsFile /dev/null" >> /root/.ssh/config \
+ && chmod 600 /root/.ssh/config && chmod 700 /root/.ssh \
+ && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+
+# using port 23 for Azure cloud, see
+# https://batch-shipyard.readthedocs.io/en/3.0.1/80-batch-shipyard-multi-instance-tasks
+EXPOSE 23
+CMD ["/usr/sbin/sshd", "-D", "-p", "23"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,6 +3,53 @@
 The present directory contains the `Dockerfile` files used to create Docker images for PetIBM.
 Once built, the Docker images are pushed and shared on the DockerHub repository `barbagroup/petibm`.
 
+## `barbagroup/petibm:0.5.2-GPU-OpenMPI-centos7`
+
+PetIBM (0.5.2) was installed along with its dependencies:
+
+* CUDA 10.1
+* OpenMPI v4.0.5 (with Infiniband, UCX, Slurm, PMI, CUDA enabled)
+* AmgX 919fb92
+* PETSc 3.12.5
+* AmgXWrapper 1a93865
+
+The base image of this version has been changed to CentOS 7 to align with the
+CentOS/Red Hat-based clusters at many HPC centers.
+
+To build the developer-version image:
+
+```shell
+docker build --target builder --tag barbagroup/petibm:0.5.2-GPU-OpenMPI-centos7-devel --file Dockerfile-0.5.2-GPU-OpenMPI-centos7 .
+```
+
+To build the production-version image:
+
+```shell
+docker build --target production --tag barbagroup/petibm:0.5.2-GPU-OpenMPI-centos7 --file Dockerfile-0.5.2-GPU-OpenMPI-centos7 .
+```
+
+To pull the built images from DockerHub:
+
+```shell
+docker pull barbagroup/petibm:0.5.2-GPU-OpenMPI-centos7
+```
+
+or
+
+```shell
+docker pull barbagroup/petibm:0.5.2-GPU-OpenMPI-centos7-devel
+```
+
+To launch a container with the GPU support and get a Bash shell:
+
+```shell
+docker run --gpus <devices> --rm --name test -it barbagroup/petibm:0.5.2-GPU-OpenMPI-centos7 /bin/bash
+```
+For specifying the GPU devices in `--gpus` flags, see the [documentation here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#gpu-enumeration)
+
+If the `/bin/bash` in Docker's `run` command is absent, by default, the PetIBM image
+will start a SSH server daemon listening to port 23.
+
 ## `barbagroup/petibm:0.5.1-GPU-OpenMPI-xenial-devel`
 
 Image based on Ubuntu 16.04 (Xenial).

--- a/singularity/README.md
+++ b/singularity/README.md
@@ -2,6 +2,14 @@
 
 The present directory contains the Singularity recipes used to create Singularity images for PetIBM on [Singularity Hub](https://singularity-hub.org/) (in [this collection](https://singularity-hub.org/collections/3692)).
 
+## `0.5.2-gpu-openmpi-centos7`
+
+To pull the Singularity image from the collection:
+
+```shell
+singularity pull --name petibm-0.5.2_centos7.sif shub://barbagroup/petibm-recipes:0.5.2-gpu-openmpi-centos7
+```
+
 ## `0.5.1-gpu-openmpi-xenial`
 
 To pull the Singularity image from the collection:

--- a/singularity/Singularity.0.5.2-GPU-OpenMPI-centos7
+++ b/singularity/Singularity.0.5.2-GPU-OpenMPI-centos7
@@ -1,0 +1,64 @@
+# vim:ft=singularity
+
+Bootstrap: docker
+From: barbagroup/petibm:0.5.2-GPU-OpenMPI-centos7
+
+# default to shell for "run" command; overwrite the Docker image's SSHD cmd
+%runscript
+    exec /bin/bash
+
+%apprun poisson
+    poisson $@
+
+%apprun solveFromFile
+    solveFromFile $@
+
+%apprun createxdmf
+    petibm-createxdmf $@
+
+%apprun decoupledibpm
+    petibm-decoupledibpm $@
+
+%apprun ibpm
+    petibm-ibpm $@
+
+%apprun navierstokes
+    petibm-navierstokes $@
+
+%apprun vorticity
+    petibm-vorticity $@
+
+%apprun writemesh
+    petibm-writemesh $@
+
+%labels
+    Author  Pi-Yueh Chuang <pychuang@gwu.edu>
+    PetIBM      v0.5.2
+    PETSc       v3.12.5
+    OpenMPI     v4.0.5
+    CUDA        v10.1
+    AmgX        919fb92
+    AmgXWrapper 1a93865
+
+%help
+
+    $ singularity run <the name of this image>
+
+        This will start a shell in the container.
+
+
+    $ singularity run --app <app name> <the name of this image> [app arguments]
+
+        apps:
+            poisson: from the Poisson example in AmgXWrapper
+            solveFromFile: from the solveFromFile example in AmgXWrapper
+            createxdmf: PetIBM application code.
+            decoupledibpm: PetIBM application code.
+            ibpm: PetIBM application code.
+            navierstokes: PetIBM application code.
+            vorticity: PetIBM application code.
+            writemesh: PetIBM application code.
+
+    $ singularity exec <the name of this image> <program name>
+        
+        This will execute the specified program in container.


### PR DESCRIPTION
New files:
1. Dockerfile
2. Singularity script

Images contain:
- CUDA 10.1
- OpenMPI v4.0.5 (with Infiniband, UCX, Slurm, PMI, CUDA enabled)
- AmgX 919fb92
- PETSc 3.12.5
- AmgXWrapper 1a93865
- PetIBM v0.5.2

Docker image has been pushed to Docker Hub. The Singularity image has not because I don't think I have the right permission to do that.